### PR TITLE
PHP7 Fix

### DIFF
--- a/acf.php
+++ b/acf.php
@@ -1,10 +1,10 @@
 <?php
 /*
-Plugin Name: Advanced Custom Fields
-Plugin URI: http://www.advancedcustomfields.com/
+Plugin Name: Advanced Custom Fields PHP7 Fix
+Plugin URI: https://github.com/R-Harda/advanced-custom-fields-php7fix
 Description: Customise WordPress with powerful, professional and intuitive fields
 Version: 4.4.7
-Author: Elliot Condon
+Author: Elliot Condon, R-Harada(PHP7-Fix)
 Author URI: http://www.elliotcondon.com/
 License: GPL
 Copyright: Elliot Condon

--- a/core/controllers/revisions.php
+++ b/core/controllers/revisions.php
@@ -159,8 +159,8 @@ class acf_revisions
 				{
 					global $left_revision, $right_revision;
 					
-					$left_revision->$field['name'] = 'revision_id=' . $_GET['left'];
-					$right_revision->$field['name'] = 'revision_id=' . $_GET['right'];
+					$left_revision->{$field['name']} = 'revision_id=' . $_GET['left'];
+					$right_revision->{$field['name']} = 'revision_id=' . $_GET['right'];
 				}
 								
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
-=== Advanced Custom Fields ===
-Contributors: elliotcondon
+=== Advanced Custom Fields PHP7-Fix ===
+Contributors: elliotcondon, R-Harada(PHP7-Fix)
 Tags: custom, field, custom field, advanced, simple fields, magic fields, more fields, repeater, matrix, post, type, text, textarea, file, image, edit, admin
 Requires at least: 3.5.0
 Tested up to: 4.5.0


### PR DESCRIPTION
PHP5.xとPHP7での互換性をつけ、php7ccでエラーを吐かないように訂正